### PR TITLE
refactor: Rename project from JulAI to JulIA

### DIFF
--- a/src/JulIA.jl
+++ b/src/JulIA.jl
@@ -1,5 +1,5 @@
-# src/JulAI.jl
-module JulAI
+# src/JulIA.jl
+module JulIA
 
 # --- Core Module ---
 module Core
@@ -9,12 +9,12 @@ module Core
     using DataStructures # For ExecutionEngine
 
     # Order matters if files depend on each other's definitions within Core
-    include("Core/DomainModels.jl") # Defines Workflow, Node, Edge structs
-    include("Core/Nodes.jl")        # Defines AbstractNode, WebhookNode, TransformDataNode, execute for them
-    include("Core/ExecutionEngine.jl") # Defines ExecutionContext, execute_workflow, helpers
-    include("Core/SandboxManager.jl")  # Defines UserCodeSandbox
+    include("JulIA/Core/DomainModels.jl") # Defines Workflow, Node, Edge structs
+    include("JulIA/Core/Nodes.jl")        # Defines AbstractNode, WebhookNode, TransformDataNode, execute for them
+    include("JulIA/Core/ExecutionEngine.jl") # Defines ExecutionContext, execute_workflow, helpers
+    include("JulIA/Core/SandboxManager.jl")  # Defines UserCodeSandbox
 
-    # Export from Core to make them accessible as JulAI.Core.XYZ
+    # Export from Core to make them accessible as JulIA.Core.XYZ
     export DomainModels, Nodes, ExecutionEngine, SandboxManager
     # Or export specific structs/functions if preferred for a flatter API from Core
     # e.g., export Workflow, Node, Edge, AbstractNode, WebhookNode, TransformDataNode,
@@ -34,7 +34,7 @@ module Application
                                  # and potentially execute_workflow if called from Application layer
     using ..Core.Nodes # If Application layer manipulates AbstractNode instances directly
 
-    include("Application/WorkflowService.jl") # Defines WorkflowService module
+    include("JulIA/Application/WorkflowService.jl") # Defines WorkflowService module
 
     export WorkflowService
 end # module Application
@@ -60,7 +60,7 @@ module Web
     using ..Core.ExecutionEngine # For execute_workflow and ExecutionContext
     using ..Application.WorkflowService # For CRUD operations on workflows
 
-    include("Web/APIController.jl") # Defines APIController module and its routes
+    include("JulIA/Web/APIController.jl") # Defines APIController module and its routes
 
     # Typically, you might not export APIController itself, but ensure its routes are loaded
     # and Genie server is started. For now, exporting it is fine for structure.
@@ -75,7 +75,7 @@ end # module Web
 
 function julia_main()::Cint
     try
-        println("JulAI Application: Initializing modules...")
+        println("JulIA Application: Initializing modules...")
         # This structure implies that Genie routes are defined when APIController.jl is included.
         # To start the server, one might call a function from Web or Web.APIController.
         # For example, if APIController had a function like `function start_server() Genie.startup() end`
@@ -85,7 +85,7 @@ function julia_main()::Cint
         # This will fail if modules are not exporting these or if paths are wrong.
         # println("Testing module access: \$(Core.DomainModels.Workflow)")
         # println("Testing API controller access: \$(Web.APIController)")
-        println("JulAI modules structured. Further setup (like starting Genie) would go here or be called from here.")
+        println("JulIA modules structured. Further setup (like starting Genie) would go here or be called from here.")
 
     catch err
         Base.showerror(stderr, err)
@@ -95,8 +95,8 @@ function julia_main()::Cint
     return 0
 end
 
-# Export key modules if you want `using JulAI` to bring them into scope,
+# Export key modules if you want `using JulIA` to bring them into scope,
 # or specific functionalities.
 export Core, Application, Web, Infrastructure, julia_main
 
-end # module JulAI
+end # module JulIA

--- a/src/JulIA/Application/WorkflowService.jl
+++ b/src/JulIA/Application/WorkflowService.jl
@@ -3,7 +3,7 @@ module WorkflowService
 using JSON3 # Directly used for JSON3.write/read.
 
 # Note: UUIDs, Dates, and Core module types (Workflow, Node, Edge) are expected to be
-# available from the parent JulAI.Application module's scope, as defined in JulAI.jl.
+# available from the parent JulIA.Application module's scope, as defined in JulIA.jl.
 # No explicit `using ..Core.DomainModels` needed here if that's the case.
 
 export save_workflow_to_string, load_workflow_from_string, save_workflow_to_file, load_workflow_from_file, list_workflow_files

--- a/src/JulIA/Core/DomainModels.jl
+++ b/src/JulIA/Core/DomainModels.jl
@@ -1,6 +1,6 @@
 module DomainModels
 
-# UUIDs and Dates are expected to be available from the parent JulAI.Core module.
+# UUIDs and Dates are expected to be available from the parent JulIA.Core module.
 
 export Node, Edge, Workflow # Export the structs so they can be used by other modules
 

--- a/src/JulIA/Core/ExecutionEngine.jl
+++ b/src/JulIA/Core/ExecutionEngine.jl
@@ -1,6 +1,6 @@
 module ExecutionEngine
 
-# UUIDs and DataStructures are expected to be available from the parent JulAI.Core module.
+# UUIDs and DataStructures are expected to be available from the parent JulIA.Core module.
 # Workflow, Node, Edge structs are now from DomainModels.
 using ..DomainModels
 # AbstractNode and its concrete types (WebhookNode, TransformDataNode) and their execute methods.

--- a/src/JulIA/Core/Nodes.jl
+++ b/src/JulIA/Core/Nodes.jl
@@ -1,11 +1,11 @@
 module Nodes
 
 # ExecutionContext is expected to be available from the ExecutionEngine module,
-# which is a sibling module within JulAI.Core.
+# which is a sibling module within JulIA.Core.
 using ..ExecutionEngine: ExecutionContext
 # UserCodeSandbox is needed for ConditionalNode's condition_code execution.
 using ..SandboxManager.UserCodeSandbox
-# Note: UUIDs and Dates are available from JulAI.Core's own `using` statements.
+# Note: UUIDs and Dates are available from JulIA.Core's own `using` statements.
 
 export AbstractNode, WebhookNode, TransformDataNode, ConditionalNode, execute
 

--- a/src/JulIA/Core/SandboxManager.jl
+++ b/src/JulIA/Core/SandboxManager.jl
@@ -1,6 +1,6 @@
 module SandboxManager
 
-# UUIDs is expected to be available from the parent JulAI.Core module.
+# UUIDs is expected to be available from the parent JulIA.Core module.
 # ExecutionContext is from ExecutionEngine module.
 using ..ExecutionEngine: ExecutionContext
 # Workflow (and Node, Edge) types are from DomainModels module.
@@ -14,7 +14,7 @@ module UserCodeSandbox
     # To be precise, since SandboxManager is a sibling of ExecutionEngine,
     # UserCodeSandbox (submodule of SandboxManager) would use:
     using ..ExecutionEngine: ExecutionContext
-    # This assumes that JulAI.Core includes SandboxManager.jl and ExecutionEngine.jl,
+    # This assumes that JulIA.Core includes SandboxManager.jl and ExecutionEngine.jl,
     # making them siblings.
 
     global input_data = nothing

--- a/src/JulIA/Web/APIController.jl
+++ b/src/JulIA/Web/APIController.jl
@@ -1,7 +1,7 @@
 module APIController
 
 # All necessary `using` statements (Genie, UUIDs, Dates, Core modules, Application modules)
-# are expected to be handled by the parent `JulAI.Web` module, as defined in `JulAI.jl`.
+# are expected to be handled by the parent `JulIA.Web` module, as defined in `JulIA.jl`.
 # This keeps APIController.jl focused on route definitions and controller logic.
 
 # --- Workflow API Routes ---


### PR DESCRIPTION
- Renamed main project directory from src/JulAI to src/JulIA.
- Renamed main project file from src/JulAI.jl to src/JulIA.jl.
- Updated main module definition from `module JulAI` to `module JulIA`.
- Corrected all `include` paths in `src/JulIA.jl` to reflect the new directory structure (e.g., `include("JulIA/Core/Nodes.jl")`).
- Updated comments and string literals across the codebase to change "JulAI" to "JulIA" for consistency.